### PR TITLE
Corrected sentence locator regex for "so" and "there is" detection.

### DIFF
--- a/lib/starts-with-so.js
+++ b/lib/starts-with-so.js
@@ -7,7 +7,7 @@
 // * http://comminfo.rutgers.edu/images/comprofiler/plug_profilegallery/84/pg_2103855866.pdf
 
 // this implementation is really naive
-var re = new RegExp('([^\\.;!?]+)([\\.;!?]+)', 'gi');
+var re = new RegExp('([^\n\\.;!?]+)([\\.;!?]+)', 'gi');
 var startsWithSo = new RegExp('^(\\s)*so\\b[\\s\\S]', 'i');
 module.exports = function (text) {
   var suggestions = [];

--- a/lib/there-is.js
+++ b/lib/there-is.js
@@ -3,7 +3,7 @@
 //          (most of the time)
 
 // this implementation is really naive
-var re = new RegExp('([^\\.;!?]+)([\\.;!?]+)', 'gi');
+var re = new RegExp('([^\n\\.;!?]+)([\\.;!?]+)', 'gi');
 var startsWithThereIs = new RegExp('^(\\s)*there\\b\\s(is|are)\\b', 'i');
 module.exports = function (text) {
   var suggestions = [];

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -125,6 +125,18 @@ describe('writeGood', function () {
   it('should have no suggestions for an empty string', function () {
     expect(writeGood('')).toEqual([]);
   });
+
+  it('should handle leading newlines on "so" detection.', function () {
+    expect(writeGood('\n\nSo adds no meaning.')).toEqual([
+      { index: 2, offset: 2, reason: '"So" adds no meaning' }
+    ]);
+  });
+
+  it('should handle leading newlines on "there is" detection.', function () {
+    expect(writeGood('\n\nthere is unnecessary verbiage.')).toEqual([
+      { index: 2, offset: 8, reason: '"there is" is unnecessary verbiage' }
+    ]);
+  });
 });
 
 describe('annotate', function () {


### PR DESCRIPTION
Sentences for the "so" and "there is" starting detector may
no longer start with whitespace.

The leading whitespace was causing an unexpected index that was
incremented by the number of leading newlines in a file. This placed
the error in an odd place, causing a lot of problems down the chain.

This patch ignores the concept of a "leading newline" and includes
some tests for making sure this works.
