### PR TITLE
Mention linter-write-good for the atom editor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ They might be helpful.
 * [natural](https://github.com/NaturalNode/natural) – general purpose NLP toolkit in JavaScript
 * [WordNet](http://wordnet.princeton.edu/) – lexical database of the English language
 * [LanguageTool](https://languagetool.org/) – style and grammar checker implemented in Java
+* [linter-write-good](https://github.com/gepoch/linter-write-good) for [Atom](https://atom.io/)
 
 ### Prose
 


### PR DESCRIPTION
Shameless self-promotion.

Now with correct markdown, even.
