### PR TITLE
bin: Exit with the number of "suggestions"

### DIFF
--- a/bin/write-good.js
+++ b/bin/write-good.js
@@ -42,10 +42,12 @@ Object.keys(opts).forEach(function (name) {
   }
 });
 
+var exitCode = 0;
 files.forEach(function (file) {
   var contents = fs.readFileSync(file, 'utf8');
   var suggestions = writeGood(contents, opts);
 
+  exitCode += suggestions.length;
   if (suggestions.length) {
     console.log('In ' + file);
     console.log('=============');
@@ -53,3 +55,4 @@ files.forEach(function (file) {
   }
 });
 
+process.exit(exitCode);


### PR DESCRIPTION
This patch makes the binary (`write-good(1)`) a bit more "unixy".  The
prior implementation exited with `0` unless a runtime error occurred.

Now running this:

``` sh
$ bin/write-good.js README.md > /dev/null && echo "hi"
```

Should not output "hi".
## 

Also, unrelated, ignore `node_modules` in git.
