### PR TITLE
Support custom language checks #64

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ var suggestions = writeGood('So the cat was stolen', { passive: false});
 // suggestions: []
 ```
 
+A third argument allows you to pass in custom checks instead of `write-good`'s default linting configuration.
+Like this, you can check non-English documents, for example with the linter extension for German language, [schreib-gut](https://github.com/TimKam/schreib-gut) (experimental):
+
+
+```javascript
+var schreibGut = require('schreib-gut');
+
+writeGood('Aller Wahrscheinlichkeit nach können Entwickler nicht gut schreiben', { weasel-words: false}, schreibGut);
+
+// or:
+writeGood('Aller Wahrscheinlichkeit nach können Entwickler nicht gut schreiben', { weasel-words: false}, schreibGut);
+
+// suggestions
+// [{index : 0, offset : 29, reason : '"Aller Wahrscheinlichkeit nach" is wordy or unneeded' }]
+```
 
 ## CLI
 
@@ -80,6 +95,12 @@ Or exclude checks like this:
 write-good *.md --no-passive
 ```
 
+To specify a custom checks extension, for example [schreib-gut](https://github.com/TimKam/schreib-gut) (experimental), run:
+
+```shell
+npm install -g schreib-gut
+write-good *.md --checks=schreib-gut
+```
 
 ## Checks
 

--- a/README.md
+++ b/README.md
@@ -43,17 +43,14 @@ var suggestions = writeGood('So the cat was stolen', { passive: false});
 // suggestions: []
 ```
 
-A third argument allows you to pass in custom checks instead of `write-good`'s default linting configuration.
+You can use the second argument's `checks` property to pass in custom checks instead of `write-good`'s default linting configuration.
 Like this, you can check non-English documents, for example with the linter extension for German language, [schreib-gut](https://github.com/TimKam/schreib-gut) (experimental):
 
 
 ```javascript
 var schreibGut = require('schreib-gut');
 
-writeGood('Aller Wahrscheinlichkeit nach können Entwickler nicht gut schreiben', { weasel-words: false}, schreibGut);
-
-// or:
-writeGood('Aller Wahrscheinlichkeit nach können Entwickler nicht gut schreiben', { weasel-words: false}, schreibGut);
+writeGood('Aller Wahrscheinlichkeit nach können Entwickler nicht gut schreiben', { weasel-words: false, checks: schreibGut});
 
 // suggestions
 // [{index : 0, offset : 29, reason : '"Aller Wahrscheinlichkeit nach" is wordy or unneeded' }]

--- a/bin/write-good.js
+++ b/bin/write-good.js
@@ -21,14 +21,12 @@ if (files.length === 0) {
 }
 
 //set custom ops, i.e. to lint a non-English document
-var optsArg = args.find(function (arg) {
+var checksModule = args.find(function (arg) {
     return arg.startsWith('--checks');
-});
-
-var checksModule = optsArg ? optsArg.replace('--checks=', '') : undefined;
+}).replace('--checks=', '');
 
 var checks;
-var opts;
+var opts = {};
 if (!checksModule) {
   opts = {
     weasel   : null,
@@ -42,7 +40,6 @@ if (!checksModule) {
   };
 } else {
   checks = require(checksModule);
-  opts = {};
   Object.keys(checksModule).forEach(function (name) {
     opts[name] = null;
   });

--- a/bin/write-good.js
+++ b/bin/write-good.js
@@ -39,10 +39,10 @@ if (!checksModule) {
     cliches  : null
   };
 } else {
-  checks = require(checksModule);
   Object.keys(checksModule).forEach(function (name) {
     opts[name] = null;
   });
+  opts.checks = require(checksModule)
 }
 
 
@@ -76,7 +76,7 @@ Object.keys(opts).forEach(function (name) {
 var exitCode = 0;
 files.forEach(function (file) {
   var contents = fs.readFileSync(file, 'utf8');
-  var suggestions = writeGood(contents, opts, checks);
+  var suggestions = writeGood(contents, opts);
 
   if(shouldParse){
     exitCode = suggestions.length > 0 ? -1 : 0;

--- a/bin/write-good.js
+++ b/bin/write-good.js
@@ -20,11 +20,12 @@ if (files.length === 0) {
 }
 
 //set custom ops, i.e. to lint a non-English document
-var checksModule = args.find(function (arg) {
+var checksArg = args.find(function (arg) {
     return arg.startsWith('--checks');
-}).replace('--checks=', '');
+});
 
-var checks;
+var checksModule = checksArg ? checksArg.replace('--checks=', '') : undefined;
+
 var opts = {};
 if (!checksModule) {
   opts = {
@@ -38,10 +39,10 @@ if (!checksModule) {
     cliches  : null
   };
 } else {
-  Object.keys(checksModule).forEach(function (name) {
+  opts.checks = require(checksModule)
+  Object.keys(opts.checks).forEach(function (name) {
     opts[name] = null;
   });
-  opts.checks = require(checksModule)
 }
 
 var include = true;
@@ -64,7 +65,7 @@ args.filter(function (arg) {
   //an operational flag: --parse, which means parse-happy output
   //and follow a more conventional Unix exit code
     shouldParse = true;
-  } else {
+  } else if (arg.indexOf('checks=') === -1) {
     opts[arg] = true;
     include = false;
   }
@@ -72,7 +73,8 @@ args.filter(function (arg) {
 
 Object.keys(opts).forEach(function (name) {
   if (typeof opts[name] !== 'boolean'
-  &&  name !== 'text') {                 // --text="text to check"
+  &&  name !== 'text'                 // --text="text to check"
+  && name !== 'checks') {             // --checks="custom-check-module"
     opts[name] = include;
   }
 });

--- a/bin/write-good.js
+++ b/bin/write-good.js
@@ -20,16 +20,34 @@ if (files.length === 0) {
   process.exit(1);
 }
 
-var opts      = {
-  weasel   : null,
-  illusion : null,
-  so       : null,
-  thereIs  : null,
-  passive  : null,
-  adverb   : null,
-  tooWordy : null,
-  cliches  : null
-};
+//set custom ops, i.e. to lint a non-English document
+var optsArg = args.find(function (arg) {
+    return arg.startsWith('--checks');
+});
+
+var checksModule = optsArg ? optsArg.replace('--checks=', '') : undefined;
+
+var checks;
+var opts;
+if (!checksModule) {
+  opts = {
+    weasel   : null,
+    illusion : null,
+    so       : null,
+    thereIs  : null,
+    passive  : null,
+    adverb   : null,
+    tooWordy : null,
+    cliches  : null
+  };
+} else {
+  checks = require(checksModule);
+  opts = {};
+  Object.keys(checksModule).forEach(function (name) {
+    opts[name] = null;
+  });
+}
+
 
 var include = true;
 var shouldParse = false;
@@ -61,7 +79,7 @@ Object.keys(opts).forEach(function (name) {
 var exitCode = 0;
 files.forEach(function (file) {
   var contents = fs.readFileSync(file, 'utf8');
-  var suggestions = writeGood(contents, opts);
+  var suggestions = writeGood(contents, opts, checks);
 
   if(shouldParse){
     exitCode = suggestions.length > 0 ? -1 : 0;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "author": "Brian Ford",
   "license": "MIT",
   "devDependencies": {
-    "jasmine-node": "2.0.0"
+    "jasmine-node": "2.0.0",
+    "schreib-gut": "0.0.1"
   },
   "dependencies": {
     "passive-voice": "~0.0.0",

--- a/test/customChecks.spec.js
+++ b/test/customChecks.spec.js
@@ -1,21 +1,23 @@
 var writeGood = require('../write-good');
 var schreibGut = require('schreib-gut');
 
-describe('if the language is set to German', function() {
+describe('if we use a custom German language check', function() {
   it('should detect German weasel words', function () {
-    expect(writeGood('Das Projekt ist noch nicht komplett beendet.', schreibGut)).toEqual([
-      { index : 27, offset : 8, reason : '"komplett" is a weasel word' }
-    ]);
+    expect(writeGood('Das Projekt ist noch nicht komplett beendet.',
+      {checks: schreibGut})).toEqual([
+        { index : 27, offset : 8, reason : '"komplett" is a weasel word' }
+      ]);
   });
 
   it('should detect German wordy phrases', function() {
-    expect(writeGood('Aller Wahrscheinlichkeit nach können Entwickler nicht gut schreiben', schreibGut)).toEqual([
-      {index : 0, offset : 29, reason : '"Aller Wahrscheinlichkeit nach" is wordy or unneeded' }
-    ]);
+    expect(writeGood('Aller Wahrscheinlichkeit nach können Entwickler nicht gut schreiben',
+      {checks: schreibGut})).toEqual([
+        {index : 0, offset : 29, reason : '"Aller Wahrscheinlichkeit nach" is wordy or unneeded' }
+      ]);
   });
 
   it('should not detect English weasel words', function() {
-    expect(writeGood('Remarkably few developers write well.', schreibGut)).toEqual([
-    ]);
+    expect(writeGood('Remarkably few developers write well.',
+      {checks: schreibGut})).toEqual([]);
   });
 });

--- a/test/customChecks.spec.js
+++ b/test/customChecks.spec.js
@@ -1,0 +1,21 @@
+var writeGood = require('../write-good');
+var schreibGut = require('schreib-gut');
+
+describe('if the language is set to German', function() {
+  it('should detect German weasel words', function () {
+    expect(writeGood('Das Projekt ist noch nicht komplett beendet.', schreibGut)).toEqual([
+      { index : 27, offset : 8, reason : '"komplett" is a weasel word' }
+    ]);
+  });
+
+  it('should detect German wordy phrases', function() {
+    expect(writeGood('Aller Wahrscheinlichkeit nach können Entwickler nicht gut schreiben', schreibGut)).toEqual([
+      {index : 0, offset : 29, reason : '"Aller Wahrscheinlichkeit nach" is wordy or unneeded' }
+    ]);
+  });
+
+  it('should not detect English weasel words', function() {
+    expect(writeGood('Remarkably few developers write well.', schreibGut)).toEqual([
+    ]);
+  });
+});

--- a/write-good.js
+++ b/write-good.js
@@ -1,4 +1,4 @@
-var checks = {
+var defaultChecks = {
   weasel  : { fn: require('weasel-words'),            explanation: 'is a weasel word' },
   illusion : { fn: require('./lib/lexical-illusions'), explanation: 'is repeated' },
   so       : { fn: require('./lib/starts-with-so'),    explanation: 'adds no meaning' },
@@ -9,13 +9,17 @@ var checks = {
   cliches  : { fn: require('no-cliches'),              explanation: 'is a cliche'},
 };
 
-module.exports = function (text, opts) {
-  opts = opts || {};
+module.exports = function (text, opts, checks) {
+  //overload opts
+  var optsType = opts ? typeof opts[Object.keys(opts)[0]] : undefined;
+  var finalOpts = optsType === 'boolean' ? opts : {};
+  var finalChecks = optsType === 'object' ? opts : checks || defaultChecks;
+
   var suggestions = [];
-  Object.keys(checks).forEach(function (checkName) {
-    if (opts[checkName] !== false) {
-      suggestions = suggestions.concat(checks[checkName].fn(text).
-                          map(reasonable(checks[checkName].explanation)));
+  Object.keys(finalChecks).forEach(function (checkName) {
+    if (finalOpts[checkName] !== false) {
+      suggestions = suggestions.concat(finalChecks[checkName].fn(text).
+                          map(reasonable(finalChecks[checkName].explanation)));
     }
   });
 

--- a/write-good.js
+++ b/write-good.js
@@ -9,11 +9,15 @@ var defaultChecks = {
   cliches  : { fn: require('no-cliches'),              explanation: 'is a cliche'},
 };
 
-module.exports = function (text, opts, checks) {
-  //overload opts
-  var optsType = opts ? typeof opts[Object.keys(opts)[0]] : undefined;
-  var finalOpts = optsType === 'boolean' ? opts : {};
-  var finalChecks = optsType === 'object' ? opts : checks || defaultChecks;
+module.exports = function (text, opts) {
+  opts = opts ? opts : {};
+  var finalOpts = {}
+  Object.keys(opts).map(function(optKey) {
+    if(optKey !== 'checks') {
+      finalOpts[optKey] = opts[optKey];
+    }
+  });
+  var finalChecks = opts.checks || defaultChecks;
 
   var suggestions = [];
   Object.keys(finalChecks).forEach(function (checkName) {


### PR DESCRIPTION
i.e. to support linting for languages other than English

Some thoughts about my implementation:
* The tests depend on the `schreib-gut` extension I wrote.
  I could move them to the `schreib-gut` package.
* I introduced a third argument (`checks` / `--checks`). Instead, we could extend
  the `opts` argument. However, this should probably come with a
  restructuring of the `opts` object and consequently some implementation
  overhead for backwards compatibility reasons.