### PR TITLE
fix broken --text flag

### DIFF
--- a/bin/write-good.js
+++ b/bin/write-good.js
@@ -14,7 +14,7 @@ if (args[0] === '--version'){
   process.exit(0);
 }
 
-if (files.length === 0) {
+if (files.length === 0 && !args.some(arg => arg.startsWith('--text'))) {
   console.log('You did not provide any files to check');
   process.exit(1);
 }


### PR DESCRIPTION
the early exit on no files means the --text flag wasnt' ever getting a chance.