### PR TITLE
 #48 add CLI help and option management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ pids
 # https://docs.npmjs.com/misc/faq#should-i-check-my-node-modules-folder-into-git
 node_modules
 
+# Editors/IDEs
+.vscode/
+

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Or include checks like this:
 write-good *.md --yes-eprime
 ```
 
+**Note:** The ``--yes`` prefix only works for *E-Prime*, because the other checks are included by default, anyway.
+
 You can run just with text without supplying files:
 
 ```shell
@@ -122,6 +124,12 @@ You can even fetch output from a remote file:
 
 ```shell
 write-good --text="$(curl https://raw.githubusercontent.com/btford/write-good/master/README.md)"
+```
+
+Use the ``--parse`` option to activate parse-happy output and a more conventional Unix exit code:
+
+```shell
+write-good *.md --parse
 ```
 
 To specify a custom checks extension, for example [schreib-gut](https://github.com/TimKam/schreib-gut), run:

--- a/bin/write-good.js
+++ b/bin/write-good.js
@@ -48,7 +48,7 @@ function generateDeactivationDescription(checkName) {
 
 function generateActivationDescription(checkName) {
   return "activate the '" +  checkName + "' check and" +
-    "deactivate all other checks that aren't explicitely activated";
+    "deactivate all other checks that aren't explicitly activated";
 }
 
 function generateCheckOptions(checkParams) {
@@ -80,7 +80,7 @@ if (!checksModule) {
   )
   .option(
     '--yes-eprime',
-    "activate 'E-Prime' check, without deactiving the other checks"
+    "activate 'E-Prime' check, without deactivating the other checks"
   );
   checks.forEach(generateCheckOptions);
 } else { // set custom ops, for example to lint a non-English document
@@ -101,9 +101,29 @@ var files = program.parse(process.argv).args;
 // 'parse' is a commander.js edge case:
 var shouldParse = Object.keys(program).indexOf('parse') !== -1;
 
-if (files.length === 0 && !args.some(arg => arg.startsWith('--text'))) {
+var hasTextArg = args.some(function(arg) {
+  return arg.startsWith('--text')
+});
+if (files.length === 0 && !hasTextArg) {
   console.log('you did not provide any files to check');
   process.exit(1);
+}
+
+// validate arguments only if no custom checks module is provided
+var hasChecks = args.some(function(arg) {
+  return arg.startsWith('--checks');
+});
+if(!hasChecks) {
+  args.slice(1).forEach(function(arg) {
+    if(arg.startsWith('--text')) return;
+    var isValid = program.options.some(function (option) {
+      return arg === option.long || arg === option.short;
+    });
+    if(!isValid) {
+      console.log('"' + arg + '" is not a valid argument');
+      process.exit(1);
+    }
+  });
 }
 
 var include = true;

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "adverb-where": "0.0.9",
+    "commander": "^2.12.2",
     "e-prime": "^0.10.2",
     "no-cliches": "^0.1.0",
     "object.assign": "^4.0.4",

--- a/test/cli.spec.js
+++ b/test/cli.spec.js
@@ -1,0 +1,143 @@
+var exec = require('child_process').exec;
+
+describe('CLI', function() {
+
+  var expectedWarningsNotWeasel = [
+    '"was killed" may be passive voice on line 3 at column 11',
+    '"the" is repeated on line 5 at column 4',
+    '"There is" is unnecessary verbiage on line 9 at column 0',
+    '"There are" is unnecessary verbiage on line 11 at column 0',
+    '"simply" can weaken meaning on line 13 at column 17',
+    '"been said" may be passive voice on line 17 at column 7',
+    '"As a matter of fact" is wordy or unneeded on line 19 at column 0',
+    '"impacted" is wordy or unneeded on line 21 at column 31',
+    '"at loose ends" is a cliche on line 23 at column 22'
+  ];
+
+  // warnings for phrases that cause only 'weasel' warnings:
+  var expectedWarningsOnlyWeasel = [
+    '"few" is a weasel word on line 1 at column 11',
+    '"few" is a weasel word on line 17 at column 22'
+  ];
+
+  // 'weasel' warnings for phrases that cause 'weasel' warnings and other warnings:
+  var expectedWarningsPartWeaselOnly = [
+    '"Remarkably" is a weasel word on line 1 at column 0',
+    '"extremely" is a weasel word on line 15 at column 17'
+  ];
+
+  // combined warnings for phrases that cause 'weasel' warnings and other warnings:
+  var expectedWarningsPartWeaselPlus = [
+    '"Remarkably" is a weasel word and can weaken meaning on line 1 at column 0',
+    '"extremely" is a weasel word and can weaken meaning on line 15 at column 17'
+  ];
+
+  // other warnings for phrases that cause 'weasel' warnings and other warnings:
+  var expectedWarningsPartWeaselMinus = [
+    '"Remarkably" can weaken meaning on line 1 at column 0',
+    '"extremely" can weaken meaning on line 15 at column 17'
+  ];
+
+  var expectedWarningsEprime = [
+    '"was" is a form of \'to be\' on line 3 at column 11',
+    '"is" is a form of \'to be\' on line 9 at column 6',
+    '"are" is a form of \'to be\' on line 11 at column 6',
+    '"is" is a form of \'to be\' on line 13 at column 14',
+    '"is" is a form of \'to be\' on line 15 at column 14',
+    '"been" is a form of \'to be\' on line 17 at column 7',
+    '"be" is a form of \'to be\' on line 19 at column 41',
+    '"be" is a form of \'to be\' on line 21 at column 18',
+    '"is" is a form of \'to be\' on line 25 at column 8'
+  ];
+
+  it('should provide the basic functionality as expected (smoke test)', function(done) {
+    exec('./bin/write-good.js ./test/texts/English.md', function(err, stdout, stderr) {
+        var expectedWarnings = expectedWarningsNotWeasel
+          .concat(expectedWarningsOnlyWeasel)
+          .concat(expectedWarningsPartWeaselPlus);
+        expectedWarnings.forEach(function(warning) {
+          expect(stdout.includes(warning)).toBe(true);
+        });
+        done();
+    });
+  });
+   
+  it('should support running only the checks provided as command line arguments', function(done) {
+    exec('./bin/write-good.js test/texts/English.md --weasel', function(err, stdout, stderr) {
+      expectedWarningsNotWeasel.forEach(function(warning) {
+        expect(stdout.includes(warning)).toBe(false);
+      });
+      var expectedWarnings = expectedWarningsOnlyWeasel.concat(expectedWarningsPartWeaselOnly);
+      expectedWarnings.forEach(function(warning) {
+        expect(stdout.includes(warning)).toBe(true);
+      });
+      done();
+    });
+  });
+  
+  it('should support deactivating checks', function(done) {
+    exec('./bin/write-good.js test/texts/English.md --no-weasel', function(err, stdout, stderr) {
+      var notExpectedWarnings = expectedWarningsOnlyWeasel.concat(expectedWarningsPartWeaselOnly);
+      notExpectedWarnings.forEach(function(warning) {
+        expect(stdout.includes(warning)).toBe(false);
+      });
+      var expectedWarnings = expectedWarningsNotWeasel.concat(expectedWarningsPartWeaselMinus);
+      expectedWarnings.forEach(function(warning) {
+        expect(stdout.includes(warning)).toBe(true);
+      });
+      done();
+    });
+  });
+
+  it('should not check for E-Prime compliance if not explicitly activated', function(done) {
+    exec('./bin/write-good.js ./test/texts/English.md', function(err, stdout, stderr) {
+      expectedWarningsEprime.forEach(function(warning) {
+        expect(stdout.includes(warning)).toBe(false);
+      });
+      done();
+    });
+  });
+
+  it('should check for E-Prime compliance if explicitly activated', function(done) {
+    exec('./bin/write-good.js ./test/texts/English.md --eprime', function(err, stdout, stderr) {
+      expectedWarningsEprime.forEach(function(warning) {
+        expect(stdout.includes(warning)).toBe(true);
+      });
+      done();
+    });
+  });
+
+  it('should support extensions', function(done) {
+    var expectedWarnings = [
+      '"komplett" is a weasel word on line 1 at column 27',
+      '"Aller Wahrscheinlichkeit nach" is wordy or unneeded on line 3 at column 0'
+    ];
+    exec('./bin/write-good.js ./test/texts/German.md --checks=schreib-gut', function(err, stdout, stderr) {
+      expectedWarnings.forEach(function(warning) {
+        expect(stdout.includes(warning)).toBe(true);
+      });
+      done();
+    });
+  });
+
+  it('should show a meaningful error message if the user provides invalid command line arguments', function(done) {
+    exec('write-good ./test/texts/German.md --nonsense', function(err, stdout, stderr) {
+      expect(stdout.trim()).toEqual('"--nonsense" is not a valid argument');
+      done();
+    });
+  });
+
+  it('should show a meaningful error message if the import of the specified extension fails', function(done) {
+    exec('./bin/write-good.js ./test/texts/German.md --checks=nonsense', function(err, stdout, stderr) {
+      expect(stdout.trim()).toEqual('could not import custom check module. Check for spelling errors and make sure you have the module installed.');
+      done();
+    });
+  });
+
+  it('should show a meaningful error message if the user does not provide any file to check', function(done) {
+  exec('./bin/write-good.js', function(err, stdout, stderr) {
+    expect(stdout.trim()).toEqual('you did not provide any files to check');
+    done();
+  });
+  });
+});

--- a/test/cli.spec.js
+++ b/test/cli.spec.js
@@ -112,7 +112,7 @@ describe('CLI', function() {
       '"komplett" is a weasel word on line 1 at column 27',
       '"Aller Wahrscheinlichkeit nach" is wordy or unneeded on line 3 at column 0'
     ];
-    exec('./bin/write-good.js ./test/texts/German.md --checks=schreib-gut', function(err, stdout, stderr) {
+    exec('./bin/write-good.js ./test/texts/German.md --checks=schreib-gut --weasel --tooWordy', function(err, stdout, stderr) {
       expectedWarnings.forEach(function(warning) {
         expect(stdout.includes(warning)).toBe(true);
       });
@@ -122,21 +122,28 @@ describe('CLI', function() {
 
   it('should show a meaningful error message if the user provides invalid command line arguments', function(done) {
     exec('write-good ./test/texts/German.md --nonsense', function(err, stdout, stderr) {
-      expect(stdout.trim()).toEqual('"--nonsense" is not a valid argument');
+      expect(stdout.trim()).toEqual('"--nonsense" is not a valid argument.');
       done();
     });
   });
 
   it('should show a meaningful error message if the import of the specified extension fails', function(done) {
     exec('./bin/write-good.js ./test/texts/German.md --checks=nonsense', function(err, stdout, stderr) {
-      expect(stdout.trim()).toEqual('could not import custom check module. Check for spelling errors and make sure you have the module installed.');
+      expect(stdout.trim()).toEqual('Could not import custom check module. Check for spelling errors and make sure you have the module installed.');
+      done();
+    });
+  });
+
+  it('should show a meaningful error message if the user provides invalid command line arguments and extension', function(done) {
+    exec('./bin/write-good.js ./test/texts/German.md --checks=schreib-gut --adverb --weasel', function(err, stdout, stderr) {
+      expect(stdout.trim()).toEqual('"--adverb" is not a valid argument.');
       done();
     });
   });
 
   it('should show a meaningful error message if the user does not provide any file to check', function(done) {
   exec('./bin/write-good.js', function(err, stdout, stderr) {
-    expect(stdout.trim()).toEqual('you did not provide any files to check');
+    expect(stdout.trim()).toEqual('You did not provide any files to check.');
     done();
   });
   });

--- a/test/customChecks.spec.js
+++ b/test/customChecks.spec.js
@@ -10,7 +10,7 @@ describe('if we use a custom German language check', function() {
   });
 
   it('should detect German wordy phrases', function() {
-    expect(writeGood('Aller Wahrscheinlichkeit nach können Entwickler nicht gut schreiben',
+    expect(writeGood('Aller Wahrscheinlichkeit nach können Entwickler nicht gut schreiben.',
       {checks: schreibGut})).toEqual([
         {index : 0, offset : 29, reason : '"Aller Wahrscheinlichkeit nach" is wordy or unneeded' }
       ]);

--- a/test/texts/English.md
+++ b/test/texts/English.md
@@ -1,0 +1,25 @@
+Remarkably few developers write well.
+
+The script was killed.
+
+the the
+
+This changes the code so that it works.
+
+There is a use for this construction.
+
+There are uses for this construction.
+
+This sentence is simply terrible.
+
+This sentence is extremely good.
+
+It has been said that few developers write well.
+
+As a matter of fact, this sentence could be simpler.
+
+Your readers will be adversely impacted by this sentence.
+
+Writing specs puts me at loose ends.
+
+'NodeJs is awesome ;)

--- a/test/texts/German.md
+++ b/test/texts/German.md
@@ -1,0 +1,3 @@
+Das Projekt ist noch nicht komplett beendet.
+
+Aller Wahrscheinlichkeit nach können Entwickler nicht gut schreiben.


### PR DESCRIPTION
Here's my implementation of a better defined CLI interface.
Key changes:
* Add CLI command line help
* Show meaningful error message if invalid command line arguments are provided
* Show meaningful error message if ``--checks`` custom module import fails
* Dynamically determine valid arguments if ``--checks`` option is provided
* ``--yes`` prefix for *E-Prime* only, bc others are active by default, anyway

I used commander.js for the command line help, because I find it fairly simple to use and it seems to be the most actively maintained alternative (at first glance).
Disabling the ``--yes`` for all checks but *E-Prime* makes IMHO sense, but could possibly break existing workflows.
Also, we could consider adding integration tests for the command line (in this or a future PR).
