### PR TITLE
Fix missing space in help output

### DIFF
--- a/bin/write-good.js
+++ b/bin/write-good.js
@@ -47,7 +47,7 @@ function generateDeactivationDescription(checkName) {
 }
 
 function generateActivationDescription(checkName) {
-  return "activate the '" +  checkName + "' check and" +
+  return "activate the '" +  checkName + "' check and " +
     "deactivate all other checks that aren't explicitly activated";
 }
 


### PR DESCRIPTION
This pull request fixes a minor visual bug where there is no space in the program help displaying the word "anddeactivate".

In the `--help` output, it currently displays:

```
    --no-weasel        deactivate the 'weasel word' check
    --weasel           activate the 'weasel word' check anddeactivate all other checks that aren't explicitly activated
    --no-illusion      deactivate the 'lexical illusion' check
    --illusion         activate the 'lexical illusion' check anddeactivate all other checks that aren't explicitly activated
    --no-so            deactivate the 'so' check
    --so               activate the 'so' check anddeactivate all other checks that aren't explicitly activated
```

Tested in v0.13.