### PR TITLE
Add configuration to build Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+*
+!bin
+!lib
+!LICENSE
+!package.json
+!package-lock.json
+!README.md
+!write-good.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:alpine
+COPY . /tmp/write-good
+RUN yarn global add --no-progress file:/tmp/write-good
+WORKDIR /srv/app
+ENTRYPOINT ["write-good"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -239,6 +239,12 @@ module.exports = {
 }
 ```
 
+## Docker
+
+You can also run this application in [Docker](https://www.docker.com). For example:
+
+`docker run -it --rm "$(pwd)":/srv/app -w /srv/app btford/write-good:latest *.md`
+
 ## See also
 
 I came across these resources while doing research to make this module.


### PR DESCRIPTION
I found Docker quite useful in using this tool as I do not have Node installed locally. I've created my own build under https://hub.docker.com/r/aarongorka/write-good/, but it'd be great to have it under your namespace. 

The Docker image can be run like so:

`docker run -it --rm -v $(pwd):/srv/app:Z aarongorka/write-good:latest --no-tooWordy content/*/*`

If you're keen, I can update README.md with a section on Docker.