### PR TITLE
96 too broad globs exception

### DIFF
--- a/bin/write-good.js
+++ b/bin/write-good.js
@@ -186,8 +186,10 @@ if (textInputSupplied) {
   displaySuggestions('text', opts['text'], opts);
 } else {
   files.forEach(function (file) {
-    var contents = fs.readFileSync(file, 'utf8');
-    displaySuggestions(file, contents, opts);
+    if (fs.lstatSync(file).isFile()) {
+      var contents = fs.readFileSync(file, 'utf8');
+      displaySuggestions(file, contents, opts);
+    }
   })
 };
 

--- a/test/cli.spec.js
+++ b/test/cli.spec.js
@@ -161,4 +161,12 @@ describe('CLI', function() {
       done();
     });
   });
+
+  it('should not try to read in directories as files when globs do not specify file ending', function(done) {
+    exec('./bin/write-good.js test/** --so', function(err, stdout, stderr) {
+      // this error is expected; we have a problem if we get a different error:
+      expect(err.toString().trim()).toEqual('Error: Command failed: ./bin/write-good.js test/** --so');
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Closes #96:  I added a simple check to ensure write-good does not try to read in directories as files. This avoids errors when using broad globs. I also added a corresponding test case.