### PR TITLE
Add test for word boundaries

### DIFF
--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -167,6 +167,12 @@ describe('writeGood', () => {
   it('should ignore white-listed words', () => {
     expect(writeGood('Never write read-only sentences.', { whitelist: ['read-only'] })).toEqual([]);
   });
+  
+  it('should parse words boundaries with dash correctly', () => {
+    expect(writeGood('A transfer visa may be required at check-in between any connecting flight.')).toEqual([
+      { index: 20, offset: 11, reason: '"be required" may be passive voice' }
+    ]);
+  });
 });
 
 describe('annotate', () => {


### PR DESCRIPTION
Detection of word boundaries used hyphens as word boundaries instead of ignoring them. 

Fix was done in package `duereg/too-wordy`

fixes: #112