### PR TITLE
bump no-cliches@0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1715,9 +1715,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "inquirer": {
@@ -2361,9 +2361,9 @@
       "dev": true
     },
     "no-cliches": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/no-cliches/-/no-cliches-0.2.2.tgz",
-      "integrity": "sha512-iEOqDAOFl6uN5jZGRj39Jdo8qALzf2HPXtpFso8+BMaDylDrUMYMwhFbfYGgxdnMlsRnxYTwv68kaXEpsHIapg=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/no-cliches/-/no-cliches-0.3.0.tgz",
+      "integrity": "sha512-F5RA5GyDsJ9dYx2nFwzzy371BbFTBInQ/gO6arT+ngrI+1sDP5cSZxkWsVLgRoLMln4rs3xXBLjD2sLa7TnV1g=="
     },
     "nopt": {
       "version": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "adverb-where": "^0.2.1",
     "commander": "^2.19.0",
     "e-prime": "^0.10.4",
-    "no-cliches": "^0.2.2",
+    "no-cliches": "^0.3.0",
     "passive-voice": "^0.1.0",
     "too-wordy": "^0.3.0",
     "weasel-words": "^0.1.1"

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -167,7 +167,7 @@ describe('writeGood', () => {
   it('should ignore white-listed words', () => {
     expect(writeGood('Never write read-only sentences.', { whitelist: ['read-only'] })).toEqual([]);
   });
-  
+
   it('should parse words boundaries with dash correctly', () => {
     expect(writeGood('A transfer visa may be required at check-in between any connecting flight.')).toEqual([
       { index: 20, offset: 11, reason: '"be required" may be passive voice' }


### PR DESCRIPTION
This bumps the no-cliches library to 0.3.0. I've changed the whitespace detection and updated the cliche list. 