### PR TITLE
Remove Nitpicker link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,6 @@ This is not an endorsement.
 These apps have similar functionality that you may find useful.
 
 * [Hemingway App](http://www.hemingwayapp.com/)
-* [Nitpicker](http://nitpickertool.com)
 * [Grammarly](https://app.grammarly.com)
 
 ## Other projects using write good


### PR DESCRIPTION
Link seems to be dead. It either redirected me to a "parking website" or some irrelevant news website (This seems to only happen when clicking the link for the first time).

**Examples**
<img width="1327" alt="Screenshot 2022-04-13 at 08 15 14" src="https://user-images.githubusercontent.com/14994778/163112551-9d36f5a2-ee5f-4f3e-884f-c4fdfabf0a7d.png">
<img width="1325" alt="Screenshot 2022-04-13 at 08 16 20" src="https://user-images.githubusercontent.com/14994778/163112563-f99c1d5c-0358-4ee4-a32f-4a5dcfc48110.png">

